### PR TITLE
Tag regex with match groups and reformatting

### DIFF
--- a/CITE-seq-count.py
+++ b/CITE-seq-count.py
@@ -83,8 +83,8 @@ def get_args():
                          required=True, type=str,
                          help=("The regex that will be used to validate an "
                                "antibody barcode structure. Must be given in "
-                               "regex syntax.\n\nExample:\n\t"
-                               "\"^[ATGC]{6}[TGC][A]{6,}\""))
+                               "regex syntax *with a single capture group.\n\n"
+                               "Example:\n\t\"^([ATGC]{6}[TGC])[A]{6,}\""))
     filters.add_argument('-hd', '--hamming-distance', dest='hamming_thresh',
                          required=True, type=int,
                          help=("Maximum hamming distance allowed for antibody "
@@ -169,7 +169,7 @@ def main():
     barcode_length = args.cb_last - args.cb_first + 1
     umi_length = args.umi_last - args.umi_first + 1
     barcode_umi_length = barcode_length + umi_length
-    barcode_slice = slice(args.cb_frst - 1, args.cb_last)
+    barcode_slice = slice(args.cb_first - 1, args.cb_last)
     umi_slice = slice(args.umi_first - 1, args.umi_last)
 
     unique_lines = set()
@@ -212,8 +212,9 @@ def main():
             # Check if UMI + TAG already in the set
             if BC_UMI_TAG not in UMI_reduce:
                 # Check structure of the TAG
-                if re.match(TAG_structure, TAG_seq):
-                    TAG_seq = TAG_seq[0:tag_length]
+                match = re.search(TAG_structure, TAG_seq)
+                if match:
+                    TAG_seq = match.group(0)[0:tag_length]
 
                     # Increment read count
                     res_table[cell_barcode]['total_reads'] += 1

--- a/CITE-seq-count.py
+++ b/CITE-seq-count.py
@@ -153,6 +153,9 @@ def main():
     # Create TAG structure filter
     # TAG_structure = re.compile(args.tag_regex.encode('utf-8'))
     TAG_structure = re.compile(args.tag_regex)
+    if TAG_structure.groups != 1:
+        raise Exception("Tag regex must have at least one match group (..). "
+                        "Provided regex has {}".format(TAG_structure.groups))
 
     # Create a set for UMI reduction. Fast way to check if it already exists
     UMI_reduce = set()

--- a/CITE-seq-count.py
+++ b/CITE-seq-count.py
@@ -1,5 +1,7 @@
-#! /usr/bin/python3
-#Authors: Christoph Hafemeister, Patrick Roelli
+#!/usr/bin/env python3
+"""
+Authors: Christoph Hafemeister, Patrick Roelli
+"""
 import sys
 import gzip
 import csv
@@ -15,96 +17,86 @@ import re
 import argparse
 from argparse import RawTextHelpFormatter
 
+
 def get_args():
-    """Get args."""
-    parser = argparse.ArgumentParser(prog='CITE Seq Count',
-        description="""This script counts matching antobody tags from two fastq files.""", formatter_class=RawTextHelpFormatter)
-    inputs = parser.add_argument_group('Inputs')
-    inputs.add_argument('-R1', '--read1',
-                        action='store',
-                        help='The path of read1 in gz format',
-                        dest='read1_path',
-                        required=True)
-    inputs.add_argument('-R2', '--read2',
-                        help='The path of read2 in gz format',
-                        dest='read2_path',
-                        required=True)
-    inputs.add_argument('-t', '--tags',
-                        help="""The path to the csv file containing the antibody \nbarcodes as well as their respective names.
+    """
+    Get args.
+    """
+    desc = "This script counts matching antobody tags from two fastq files."
+    parser = argparse.ArgumentParser(prog='CITE Seq Count', description=desc,
+                                     formatter_class=RawTextHelpFormatter)
 
-Example of an antibody barcode file structure:
+    input_desc = "Required input files."
+    inputs = parser.add_argument_group('Inputs', description=input_desc)
 
-ATGCGA,First_tag_name
-GTCATG,Second_tag_name""",
-                        dest='tags',
-                        required=True)
-    barcodes = parser.add_argument_group('Barcodes', description="""Positions of the cellular barcodes and UMI.
-If your cellular barcodes and UMI are positioned as follows:
-Barcodes from 1 to 16 and UMI from 17 to 26, then this is the input you need:
--cbf 1 -cbl 16 -umif 17 -umil 26""")
-    barcodes.add_argument('-cbf', '--cell_barcode_first_base',
-                        help='Postion of the first base of your cell barcodes',
-                        dest='cb_first',
-                        required=True, 
-                        type=int)
-    barcodes.add_argument('-cbl', '--cell_barcode_last_base',
-                        help='Postion of the last base of your cell barcodes',
-                        dest='cb_last',
-                        required=True, 
-                        type=int)
-    barcodes.add_argument('-umif', '--umi_first_base',
-                        help='Postion of the first base of your UMI',
-                        dest='umi_first',
-                        required=True, 
-                        type=int)
-    barcodes.add_argument('-umil', '--umi_last_base',
-                        help='Postion of the last base of your UMI',
-                        dest='umi_last',
-                        required=True, 
-                        type=int)
+    inputs.add_argument('-R1', '--read1', dest='read1_path', required=True,
+                        help="The path of read1 in gz format.")
+    inputs.add_argument('-R2', '--read2', dest='read2_path', required=True,
+                        help="The path of read2 in gz format.")
+    inputs.add_argument('-t', '--tags', dest='tags', required=True,
+                        help=("The path to the csv file containing the "
+                              "antibody\nbarcodes as well as their respective "
+                              "names.\n\nExample of an antibody barcode file "
+                              "structure:\n\n"
+                              "ATGCGA,First_tag_name\n"
+                              "GTCATG,Second_tag_name"))
+
+    bc_desc = ("Positions of the cellular barcodes and UMI.  If your cellular "
+               "barcodes and UMI are positioned as follows:\n"
+               "\tBarcodes from 1 to 16 and UMI from 17 to 26\n"
+               "then this is the input you need:\n"
+               "\t-cbf 1 -cbl 16 -umif 17 -umil 26")
+    barcodes = parser.add_argument_group('Barcodes', description=bc_desc)
+
+    barcodes.add_argument('-cbf', '--cell_barcode_first_base', dest='cb_first',
+                          required=True, type=int,
+                          help=("Postion of the first base of your cell "
+                                "barcodes."))
+    barcodes.add_argument('-cbl', '--cell_barcode_last_base', dest='cb_last',
+                          required=True, type=int,
+                          help=("Postion of the last base of your cell "
+                                "barcodes."))
+    barcodes.add_argument('-umif', '--umi_first_base', dest='umi_first',
+                          required=True, type=int,
+                          help="Postion of the first base of your UMI.")
+    barcodes.add_argument('-umil', '--umi_last_base', dest='umi_last',
+                          required=True, type=int,
+                          help="Postion of the last base of your UMI.")
+
     barcodes_filtering = parser.add_mutually_exclusive_group(required=True)
-    barcodes_filtering.add_argument('-cells', '--expected_cells',
-                        help='Number of expected cells from your run',
-                        dest='cells',
-                        required=False, 
-                        type=int)
-    barcodes_filtering.add_argument('-wl', '--whitelist',
-                        help="""A csv file containning a whitelist of barcodes produced by the mRNA data
+    barcodes_filtering.add_argument('-cells', '--expected_cells', dest='cells',
+                                    required=False, type=int,
+                                    help=("Number of expected cells from your "
+                                          "run."))
+    whitelist_help = ("A csv file containning a whitelist of barcodes produced"
+                      " by the mRNA data.\n\n\tExample:\n\tATGCTAGTGCTA\n"
+                      "\tGCTAGTCAGGAT\n\tCGACTGCTAACG\n")
+    barcodes_filtering.add_argument('-wl', '--whitelist', dest='whitelist',
+                                    required=False, type=str,
+                                    help=whitelist_help)
 
-Example:
-ATGCTAGTGCTA
-GCTAGTCAGGAT
-CGACTGCTAACG
-""",
-                        dest='whitelist',
-                        required=False, 
-                        type=str)
-    
-    
-    filters = parser.add_argument_group('filters', description="""Filtering for structure of antobody barcodes as well as maximum hamming distance.""")
-    filters.add_argument('-tr', '--TAG_regex',
-                        help="""The regex that will be used to validate an antibody barcode structure. Must be given in regex syntax.
-example:
-\"^[ATGC]{6}[TGC][A]{6,}\"""",
-                        dest='tag_regex',
-                        required=True, 
-                        type=str)
-    filters.add_argument('-hd', '--hamming-distance',
-                        help='Maximum hamming distance allowed for antibody barcode',
-                        dest='hamming_thresh',
-                        required=True, 
-                        type=int)
-    parser.add_argument('-n','--first_n',
-                        required=False,
-                        help='Select n reads to run on instead of all',
-                        type=int,
-                        dest='first_n',
-                        default=None)
-    parser.add_argument('-o','--output',
-                        required=True,
-                        help='write result to file',
-                        type=str,
-                        dest='outfile')
+    filters_desc = ("Filtering for structure of antibody barcodes as well as "
+                    "maximum hamming distance.")
+    filters = parser.add_argument_group('filters', description=filters_desc)
+
+    filters.add_argument('-tr', '--TAG_regex', dest='tag_regex',
+                         required=True, type=str,
+                         help=("The regex that will be used to validate an "
+                               "antibody barcode structure. Must be given in "
+                               "regex syntax.\n\nExample:\n\t"
+                               "\"^[ATGC]{6}[TGC][A]{6,}\""))
+    filters.add_argument('-hd', '--hamming-distance', dest='hamming_thresh',
+                         required=True, type=int,
+                         help=("Maximum hamming distance allowed for antibody "
+                               "barcode."))
+    parser.add_argument('-n', '--first_n', required=False, type=int,
+                        dest='first_n', default=None,
+                        help="Select n reads to run on instead of all.")
+    parser.add_argument('-o', '--output', required=True, type=str,
+                        dest='outfile', help="Write result to file.")
+    parser.add_argument('--debug', action='store_true',
+                        help="Print extra information for debugging.")
+
     return parser
 
 
@@ -112,117 +104,173 @@ def parse_whitelist_csv(args):
     file = open(args.whitelist, mode='r')
     csvReader = csv.reader(file)
     length_barcodes = args.cb_last - args.cb_first + 1
-    whitelist = [row[0].strip() for row in csvReader if (len(row[0].strip()) == length_barcodes)]
-    return(set(whitelist))
+    whitelist = [row[0].strip() for row in csvReader
+                 if (len(row[0].strip()) == length_barcodes)]
+    return set(whitelist)
+
 
 def parse_tags_csv(filename):
     file = open(filename, mode='r')
     csvReader = csv.reader(file)
     odict = OrderedDict()
     for row in csvReader:
-        #odict[row[0].encode('utf-8')] = row[1]
         odict[row[0]] = row[1]
     return odict
 
 
 def check_tags(ab_map, maximum_dist):
     ab_barcodes = ab_map.keys()
-    for a,b in combinations(ab_barcodes,2):
-        if(len(a)!=len(b)):
-            sys.exit('Lenght of {} is different than length of {}. Can only run with all TAGS having the same length; exiting'.format(ab_map[a], ab_map[b]))
-        if(Levenshtein.hamming(a,b)<= maximum_dist):
-            sys.exit('Minimum hamming distance of TAGS barcode is less than given threshold\nPlease use a smaller distance; exiting')
-    #Return length of TAGS. Since all are the same lenght, return the length of last a
-    return(len(a))
-
+    for a, b in combinations(ab_barcodes, 2):
+        if len(a) != len(b):
+            sys.exit(("Length of {} is different than length of {}.\nCan only "
+                      "run with all TAGS having the same length.\n"
+                      "Exiting").format(ab_map[a], ab_map[b]))
+        if Levenshtein.hamming(a, b) <= maximum_dist:
+            sys.exit(("Minimum hamming distance of TAGS barcode is less than "
+                      "given threshold\nPlease use a smaller distance.\n"
+                      "Exiting."))
+    # Return length of TAGS. Since all are the same length, return the length
+    # of last a
+    return len(a)
 
 
 def main():
     parser = get_args()
     if not sys.argv[1:]:
-        sys.exit(parser.print_help())
-    #Load args
+        parser.print_help(file=sys.stderr)
+        sys.exit(2)
+
+    # Load args
     args = parser.parse_args()
-    if(args.whitelist):
+    if args.whitelist:
         whitelist = parse_whitelist_csv(args)
-    #Load TAGS barcodes
+
+    # Load TAGS barcodes
     ab_map = parse_tags_csv(args.tags)
-    #Chekck hamming threshold
+    # Check hamming threshold
     tag_length = check_tags(ab_map, args.hamming_thresh)
-    #Create TAG structure filter
-    #TAG_structure = re.compile(args.tag_regex.encode('utf-8'))
+
+    # Create TAG structure filter
+    # TAG_structure = re.compile(args.tag_regex.encode('utf-8'))
     TAG_structure = re.compile(args.tag_regex)
-    #Create a set for UMI reduction. Fast way to check if it already exists
+
+    # Create a set for UMI reduction. Fast way to check if it already exists
     UMI_reduce = set()
-    #Create result table
-    res_table = defaultdict(lambda : defaultdict(int))
-    # set counter
+    # Create result table
+    res_table = defaultdict(lambda: defaultdict(int))
+
+    # Set counter
     n = 0
     top_n = None
-    if(args.first_n):
+    if args.first_n:
         top_n = args.first_n * 4
+
+    # Define slices
+    barcode_length = args.cb_last - args.cb_first + 1
+    umi_length = args.umi_last - args.umi_first + 1
+    barcode_umi_length = barcode_length + umi_length
+    barcode_slice = slice(args.cb_frst - 1, args.cb_last)
+    umi_slice = slice(args.umi_first - 1, args.umi_last)
+
     unique_lines = set()
-    with gzip.open(args.read1_path, 'rt') as textfile1, gzip.open(args.read2_path, 'rt') as textfile2: 
-        #Read all 2nd lines from 4 line chunks
+    with gzip.open(args.read1_path, 'rt') as textfile1, \
+            gzip.open(args.read2_path, 'rt') as textfile2:
+        # Read all 2nd lines from 4 line chunks
         secondlines = islice(zip(textfile1, textfile2), 1, top_n, 4)
         print('loading')
+
         t = time.time()
         for x, y in secondlines:
-            #print(x,y)
             x = x.strip()
             y = y.strip()
-            #print(x,y)
-            line = x[(args.cb_first-1):args.cb_last] +x[args.umi_first-1: args.umi_last] + y
+            line = x[barcode_slice] + x[umi_slice] + y
             unique_lines.add(line)
-            n+=1
-            if(n%1000000 == 0):
-                print("Loaded last 1,000,000 lines in {:.3} seconds. Total lines loaded {:,} ".format(time.time()-t, n))
+
+            n += 1
+            if n % 1000000 == 0:
+                print("Loaded last 1,000,000 lines in {:.3} seconds. Total "
+                      "lines loaded {:,} ".format(time.time()-t, n))
                 t = time.time()
+
         print('{} lines loaded'.format(n))
         print('{:,} uniques lines loaded'.format(len(unique_lines)))
-        n=0
+
+        n = 0
         for line in unique_lines:
-            cell_barcode = line[0:args.cb_last-args.cb_first+1]
-            if(args.whitelist):
-                if(cell_barcode not in whitelist):
+            cell_barcode = line[0:barcode_length]
+            if args.whitelist:
+                if cell_barcode not in whitelist:
                     continue
-            UMI = line[len(cell_barcode):len(cell_barcode)+args.umi_last-args.umi_first+1]
-            BC_UMI = cell_barcode + UMI
-            TAG_seq = line[len(BC_UMI):]
+
+            UMI = line[barcode_length:barcode_umi_length]
+            TAG_seq = line[barcode_umi_length:]
             BC_UMI_TAG = cell_barcode + UMI + TAG_seq
-            #print("{0}\t{1}\t{2}\t{3}".format(line, cell_barcode, UMI,TAG_seq))
-            if BC_UMI_TAG not in UMI_reduce:#check if UMI + TAG already in the set
-                if re.match(TAG_structure, TAG_seq):#check structure of the TAG
+            if args.debug:
+                print("{0}\t{1}\t{2}\t{3}".format(line, cell_barcode,
+                                                  UMI, TAG_seq))
+
+            # Check if UMI + TAG already in the set
+            if BC_UMI_TAG not in UMI_reduce:
+                # Check structure of the TAG
+                if re.match(TAG_structure, TAG_seq):
                     TAG_seq = TAG_seq[0:tag_length]
-                    res_table[cell_barcode]['total_reads'] += 1 #increment read count
+
+                    # Increment read count
+                    res_table[cell_barcode]['total_reads'] += 1
+
+                    # Get distance from all barcodes
                     temp_res = defaultdict()
                     for key, value in ab_map.items():
-                        temp_res[value] = Levenshtein.hamming(TAG_seq, key) #Get distance from all barcodes
-                    best = list(temp_res.keys())[list(temp_res.values()).index(min(temp_res.values()))]#Get smallest value and get respective tag_name
-                    if(not isinstance(min(temp_res.values()),int)):# ambiguous
-                        #print("{0}\t{1}\t{2}\t{3}\t{4}".format(cell_barcode, UMI, x,y,TAG_seq))
+                        temp_res[value] = Levenshtein.hamming(TAG_seq, key)
+
+                    # Get smallest value and get respective tag_name
+                    min_value = min(temp_res.values())
+                    min_index = list(temp_res.values()).index(min_value)
+                    best = list(temp_res.keys())[min_index]
+
+                    # ambiguous
+                    if not isinstance(min_value, int):
+                        if args.debug:
+                            print("{0}\t{1}\t{2}\t{3}\t{4}".format(
+                                  cell_barcode, UMI, x, y, TAG_seq))
+
                         res_table[cell_barcode]['ambiguous'] += 1
-                        continue #next entry
-                    if(min(temp_res.values()) >= args.hamming_thresh):#If over threshold
+                        continue
+
+                    # If over threshold
+                    if min_value >= args.hamming_thresh:
                         res_table[cell_barcode]['no_match'] += 1
-                        continue #next entry
-                    res_table[cell_barcode][best]+=1
+                        continue
+
+                    res_table[cell_barcode][best] += 1
+
+                # Increment bad structure
                 else:
-                    res_table[cell_barcode]['bad_struct'] += 1 #Increment bad structure
-                UMI_reduce.add(BC_UMI_TAG) # Add BC_UMI_TAG to set    
-            n+=1
-            if(n%1000000 == 0):
-                print("Processed 1,000,000 lines in {:.4} secondes. Total lines processed: {:,}".format(time.time()-t, n))
+                    res_table[cell_barcode]['bad_struct'] += 1
+
+                # Add BC_UMI_TAG to set
+                UMI_reduce.add(BC_UMI_TAG)
+
+            n += 1
+            if n % 1000000 == 0:
+                print("Processed 1,000,000 lines in {:.4} secondes. Total "
+                      "lines processed: {:,}".format(time.time()-t, n))
                 t = time.time()
-    print('Done counting')
-    
+
+    print("Done counting")
+
     res_matrix = pd.DataFrame(res_table)
     res_matrix.fillna(0, inplace=True)
-    if(args.cells):
-        most_reads_ordered = res_matrix.sort_values(by='total_reads', ascending=False, axis=1).axes[1]
+
+    if args.cells:
+        most_reads_ordered = res_matrix.sort_values(by='total_reads',
+                                                    ascending=False,
+                                                    axis=1).columns
         n_top_cells = int(args.cells + args.cells/100 * 30)
-        top_Cells = most_reads_ordered[0:(n_top_cells)]
-        res_matrix = res_matrix.loc[:,(res_matrix.columns.isin(top_Cells))]    
+        top_Cells = most_reads_ordered[0:n_top_cells]
+        res_matrix = res_matrix.loc[:, res_matrix.columns.isin(top_Cells)]
+
     res_matrix.to_csv(args.outfile, float_format='%.f')
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Hey,

Great tool!  I've been using this to recapitulate the results in the [bioRxiv paper](https://www.biorxiv.org/content/early/2017/12/21/237693) and to perform similar multiplexing-via-tag experiments.

One limitation that I ran into with the initial implementation was that the script expected the tag sequence to start at position 0 of read 2.  For some experiments we performed, the variable portion of the tags were downstream of position 0.  To get around this, I changed the regex from matching to searching using regex groups.  The current implementation isn't super robust, but will check that exactly one match group is supplied in the compiled tag regex.

Otherwise, I just reformatting things so that pep8 wouldn't complain.

I tested this implementation versus the original on some test data, but it may need to be further validated before merging.

Edit:  You will also want to change the [Running-the-script wiki page](https://github.com/Hoohm/CITE-seq-Count/wiki/Running-the-script#filtering) from:

> [Required] Structure of the sequenced antibody-oligo tag in regular expression. This filters potential PCR artifacts (without a polyA tail) from true ADT reads (containing a polyA tail). For 15 nucleotide antibody barcodes and a read 2 of at least 21 nucleotides this would be "^[ATGC]{15}[TGC][A]{6,}"
> 
> -tr TAG_REGEX, --TAG_regex TAG_REGEX
> 
> Example: "^[ATGC]{15}[TGC][A]{6,}"
> 

to

> [Required] Structure of the sequenced antibody-oligo tag in regular expression. This filters potential PCR artifacts (without a polyA tail) from true ADT reads (containing a polyA tail). For 15 nucleotide antibody barcodes and a read 2 of at least 21 nucleotides this would be **"^([ATGC]{15}[TGC])[A]{6,}"**
> 
> -tr TAG_REGEX, --TAG_regex TAG_REGEX
> 
> Example: **"^([ATGC]{15}[TGC])[A]{6,}"**
> 