### PR TITLE
Add argument to write unknown tags to file

### DIFF
--- a/cite_seq_count/__main__.py
+++ b/cite_seq_count/__main__.py
@@ -222,6 +222,7 @@ def main():
     UMI_reduce = set()
     # Create result table
     res_table = defaultdict(lambda: defaultdict(int))
+    no_match_table = defaultdict(lambda: defaultdict(int))
 
     # Set counter
     n = 0
@@ -311,6 +312,7 @@ def main():
                         # If over threshold
                         if min_value >= args.hamming_thresh:
                             res_table[cell_barcode]['no_match'] += 1
+                            no_match_table[best] += 1
                             continue
 
                         res_table[cell_barcode][best] += 1
@@ -341,6 +343,10 @@ def main():
         res_matrix = res_matrix.loc[:, res_matrix.columns.isin(top_Cells)]
 
     res_matrix.to_csv(args.outfile, float_format='%.f')
+    
+    print('top unknown tags:')
+    for key, value in sorted(no_match_table.iteritems(), key=lambda (k,v): (v,k)).reverse():
+        print("{0}\t{1}".format(key, value)
 
 if __name__ == '__main__':
     main()

--- a/cite_seq_count/__main__.py
+++ b/cite_seq_count/__main__.py
@@ -224,7 +224,7 @@ def main():
     UMI_reduce = set()
     # Create result table
     res_table = defaultdict(lambda: defaultdict(int))
-    no_match_table = defaultdict(lambda: defaultdict(int))
+    no_match_table = defaultdict(int)
 
     # Set counter
     n = 0
@@ -314,7 +314,7 @@ def main():
                         # If over threshold
                         if min_value >= args.hamming_thresh:
                             res_table[cell_barcode]['no_match'] += 1
-                            no_match_table[best] += 1
+                            no_match_table[TAG_seq] += 1
                             continue
 
                         res_table[cell_barcode][best] += 1
@@ -347,9 +347,9 @@ def main():
     res_matrix.to_csv(args.outfile, float_format='%.f')
     
     if args.unknowns_file:
-        no_match_matrix = pd.DataFrame(tag=no_match_table.keys(), counts=no_match_table.values())
-        no_match_matrix = no_match_matrix.sort_values(by='counts', ascending=False)      
-        no_match_matrix.to_csv(args.unknowns_file, float_format='%.f')
+        no_match_matrix = pd.DataFrame(no_match_table.items(), columns=['tag', 'total'])
+        no_match_matrix = no_match_matrix.sort_values(by='total', ascending=False)            
+        no_match_matrix.to_csv(args.unknowns_file, float_format='%.f', index=False)
                   
 
 if __name__ == '__main__':

--- a/cite_seq_count/__main__.py
+++ b/cite_seq_count/__main__.py
@@ -88,6 +88,8 @@ def get_args():
                         help="Select n reads to run on instead of all.")
     parser.add_argument('-o', '--output', required=True, type=str,
                         dest='outfile', help="Write result to file.")
+    parser.add_argument('-u', '--unknown-tags', required=False, type=str,
+                        dest='unknowns_file', help="Write table of unknown tags to file.")
     parser.add_argument('--debug', action='store_true',
                         help="Print extra information for debugging.")
     regex_pattern = parser.add_mutually_exclusive_group(required=False)
@@ -344,9 +346,11 @@ def main():
 
     res_matrix.to_csv(args.outfile, float_format='%.f')
     
-    print('top unknown tags:')
-    for key, value in sorted(no_match_table.iteritems(), key=lambda (k,v): (v,k)).reverse():
-        print("{0}\t{1}".format(key, value)
+    if args.unknowns_file:
+        no_match_matrix = pd.DataFrame(tag=no_match_table.keys(), counts=no_match_table.values())
+        no_match_matrix = no_match_matrix.sort_values(by='counts', ascending=False)      
+        no_match_matrix.to_csv(args.unknowns_file, float_format='%.f')
+                  
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This is related to issue #10.  This PR adds an argument that causes CITE-seq-count to write a CSV with any tag sequences not matching a known tag.  This could be useful if the fraction of no_match tags is high, and could help for debugging and/or identify situations where the barcodes actually used do not match what the user expected.