### PR TITLE
Support umi-tools=1.0.0 in processing.py

### DIFF
--- a/cite_seq_count/processing.py
+++ b/cite_seq_count/processing.py
@@ -183,7 +183,6 @@ def correct_umis(final_results, collapsing_threshold):
             if len(final_results[cell_barcode][TAG]) > 1:
                 umi_clusters = network.UMIClusterer()
                 UMIclusters = umi_clusters(
-                    final_results[cell_barcode][TAG].keys(),
                     final_results[cell_barcode][TAG],
                     collapsing_threshold)
                 for umi_cluster in UMIclusters:  # This is a list with the first element the dominant barcode

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
           'python-levenshtein>=0.12.0',
           'scipy>=1.1.0',
           'multiprocess>=0.70.6.1',
-          'umi_tools>=0.5.5',
+          'umi_tools>=1.0.0',
           'pytest==4.1.0',
           'pytest-dependency==0.4.0',
           'pandas>=0.23.4'


### PR DESCRIPTION
umi-tools=1.0.0 seems to change the behavior of `network.UMIClusterer.__call__(umis, threshold)`. It only needs two arguments since 1.0.0 (https://github.com/CGATOxford/UMI-tools/commit/8bcfe9cf3f182c9b3a544d020c2af97a756ba083).