### PR TITLE
allow patch releases of umi_tools 1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
           'python-levenshtein>=0.12.0',
           'scipy>=1.1.0',
           'multiprocess>=0.70.6.1',
-          'umi_tools==1.0.0',
+          'umi_tools==1.0',
           'pytest==4.1.0',
           'pytest-dependency==0.4.0',
           'pandas>=0.23.4',


### PR DESCRIPTION
Hello,
umi tools 1.0.1 was already released in December https://github.com/CGATOxford/UMI-tools/releases
With a normal fresh install of everything you get:
Traceback (most recent call last):
  File "/opt/conda/envs/bio/bin/CITE-seq-Count", line 5, in <module>
    from cite_seq_count.__main__ import main
  File "/opt/conda/envs/bio/lib/python3.8/site-packages/cite_seq_count/__main__.py", line 26, in <module>
    version = pkg_resources.require("cite_seq_count")[0].version
  File "/opt/conda/envs/bio/lib/python3.8/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/opt/conda/envs/bio/lib/python3.8/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (umi-tools 1.0.1 (/opt/conda/envs/bio/lib/python3.8/site-packages), Requirement.parse('umi-tools==1.0.0'), {'cite-seq-count'})
