### PR TITLE
Convert `columns` from set to list before creating pd.DataFrame()

### DIFF
--- a/cite_seq_count/io.py
+++ b/cite_seq_count/io.py
@@ -45,7 +45,7 @@ def write_dense(sparse_matrix, index, columns, outfolder, filename):
     """
     prefix = os.path.join(outfolder)
     os.makedirs(prefix, exist_ok=True)
-    pandas_dense = pd.DataFrame(sparse_matrix.todense(), columns=columns, index=index)
+    pandas_dense = pd.DataFrame(sparse_matrix.todense(), columns=list(columns), index=index)
     pandas_dense.to_csv(os.path.join(outfolder,filename), sep='\t')
 
 


### PR DESCRIPTION
Closes #192 

Pandas' DataFrame() constructor used to accept a `set` as its `columns` argument, but no longer does.

This simply converts the `set` to a `list` before creating the data frame. There may be better approaches to deal with this issue, but I'm not familiar enough with this package to know about them.